### PR TITLE
[DELTA][VARIANT] Add additional Variant tests and allow variant as DeltaDataSource type

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
@@ -42,7 +42,7 @@ import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.execution.streaming.{Sink, Source}
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.streaming.OutputMode
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{DataType, StructType, VariantType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 /** A DataSource V1 for integrating Delta into Spark SQL batch and Streaming APIs. */
@@ -250,6 +250,11 @@ class DeltaDataSource
         options = dfOptions
       ).toBaseRelation
     }
+  }
+
+  // Extend the default `supportsDataType` to allow VariantType.
+  override def supportsDataType(dt: DataType): Boolean = {
+    dt.isInstanceOf[VariantType] || super.supportsDataType(dt)
   }
 
   override def shortName(): String = {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeleteSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeleteSuiteBase.scala
@@ -528,4 +528,16 @@ abstract class DeleteSuiteBase extends QueryTest
     text = "SELECT * FROM (SELECT * FROM tab AS t1) AS t2",
     expectResult = Row(0, 3) :: Nil
   )
+
+  test("Variant type") {
+    val dstDf = sql(
+      """SELECT parse_json(cast(id as string)) v, id i
+      FROM range(3)""")
+    append(dstDf)
+
+    executeDelete(target = s"delta.`$tempPath`", where = "to_json(v) = '1'")
+
+    checkAnswer(readDeltaTable(tempPath).selectExpr("i", "to_json(v)"),
+      Seq(Row(0, "0"), Row(2, "2")))
+  }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTableSuite.scala
@@ -57,6 +57,19 @@ class DeltaInsertIntoSQLSuite
     }
   }
 
+  test("Variant type") {
+    withTable("t") {
+      sql("CREATE TABLE t (id LONG, v VARIANT) USING delta")
+      sql("INSERT INTO t (id, v) VALUES (1, parse_json('{\"a\": 1}'))")
+      sql("INSERT INTO t (id, v) VALUES (2, parse_json('{\"b\": 2}'))")
+      sql(
+        "INSERT INTO t SELECT id, parse_json(cast(id as string)) v FROM range(2)")
+
+      checkAnswer(sql("select * from t").selectExpr("id", "to_json(v)"),
+        Seq(Row(1, "{\"a\":1}"), Row(2, "{\"b\":2}"), Row(0, "0"), Row(1, "1")))
+    }
+  }
+
   test("insert overwrite should work with selecting constants") {
     withTable("t1") {
       sql("CREATE TABLE t1 (a int, b int, c int) USING delta PARTITIONED BY (b, c)")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
@@ -702,6 +702,34 @@ abstract class MergeIntoSuiteBase
     }
   }
 
+  test("Variant type") {
+    withTable("source") {
+      // Insert ("0", 0), ("1", 1)
+      val dstDf = sql(
+        """SELECT parse_json(cast(id as string)) v, id i
+        FROM range(2)""")
+      append(dstDf)
+      // Insert ("1", 2), ("2", 3)
+      // The first row will update, the second will insert.
+      sql(
+        s"""SELECT parse_json(cast(id as string)) v, id + 1 i
+              FROM range(1, 3)""").createOrReplaceTempView("source")
+
+      executeMerge(
+        target = s"delta.`$tempPath` as trgNew",
+        source = "source src",
+        condition = "to_json(src.v) = to_json(trgNew.v)",
+        update = "i = 10 + src.i + trgNew.i, v = trgNew.v",
+        insert = """(i, v) VALUES (i + 100, parse_json('"inserted"'))""")
+
+      checkAnswer(readDeltaTable(tempPath).selectExpr("i", "to_json(v)"),
+        Row(0, "0") :: // No change
+          Row(13, "1") :: // Update
+          Row(103, "\"inserted\"") :: // Insert
+          Nil)
+    }
+  }
+
   // Enable this test in OSS when Spark has the change to report better errors
   // when MERGE is not supported.
   ignore("Negative case - non-delta target") {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableDDLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableDDLSuite.scala
@@ -398,6 +398,22 @@ trait ClusteredTableCreateOrReplaceDDLSuiteBase
     }
   }
 
+  test("Variant is not supported") {
+    val e = intercept[DeltaAnalysisException] {
+      createOrReplaceClusteredTable("CREATE", testTable, "id long, v variant", "v")
+    }
+    checkError(
+      e,
+      "DELTA_CLUSTERING_COLUMN_MISSING_STATS",
+      parameters = Map(
+        "columns" -> "v",
+        "schema" -> """root
+                      | |-- id: long (nullable = true)
+                      | |-- v: variant (nullable = true)
+                      |""".stripMargin)
+    )
+  }
+
   protected def withTempDirIfNecessary(f: Option[String] => Unit): Unit = {
     if (isPathBased) {
       withTempDir { dir =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
