### PR TITLE
[POC][KERNEL][VARIANT] Extract variant fields to directly return to the connector

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -369,6 +369,8 @@ lazy val kernelDefaults = (project in file("kernel/kernel-defaults"))
     crossSparkSettings(),
     libraryDependencies ++= Seq(
       "org.apache.hadoop" % "hadoop-client-runtime" % hadoopVersion,
+      // can we cross compile spark-variant?
+      // "org.apache.spark" %% "spark-variant" % SPARK_MASTER_VERSION % "provided",
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.5",
       "org.apache.parquet" % "parquet-hadoop" % "1.12.3",
 

--- a/build.sbt
+++ b/build.sbt
@@ -38,6 +38,8 @@ val LATEST_RELEASED_SPARK_VERSION = "3.5.0"
 val SPARK_MASTER_VERSION = "4.0.0-SNAPSHOT"
 val sparkVersion = settingKey[String]("Spark version")
 spark / sparkVersion := getSparkVersion()
+kernelDefaults / sparkVersion := getSparkVersion()
+goldenTables / sparkVersion := getSparkVersion()
 
 // Dependent library versions
 val defaultSparkVersion = LATEST_RELEASED_SPARK_VERSION
@@ -127,6 +129,25 @@ lazy val commonSettings = Seq(
 )
 
 /**
+ * Java-/Scala-/Uni-Doc settings aren't working yet against Spark Master.
+    1) delta-spark on Spark Master uses JDK 17. delta-iceberg uses JDK 8 or 11. For some reason,
+       generating delta-spark unidoc compiles delta-iceberg
+    2) delta-spark unidoc fails to compile. spark 3.5 is on its classpath. likely due to iceberg
+       issue above.
+ */
+def crossSparkProjectSettings(): Seq[Setting[_]] = getSparkVersion() match {
+  case LATEST_RELEASED_SPARK_VERSION => Seq(
+    // Java-/Scala-/Uni-Doc Settings
+    scalacOptions ++= Seq(
+      "-P:genjavadoc:strictVisibility=true" // hide package private types and methods in javadoc
+    ),
+    unidocSourceFilePatterns := Seq(SourceFilePattern("io/delta/tables/", "io/delta/exceptions/"))
+  )
+
+  case SPARK_MASTER_VERSION => Seq()
+}
+
+/**
  * Note: we cannot access sparkVersion.value here, since that can only be used within a task or
  *       setting macro.
  */
@@ -140,12 +161,6 @@ def crossSparkSettings(): Seq[Setting[_]] = getSparkVersion() match {
     Compile / unmanagedSourceDirectories += (Compile / baseDirectory).value / "src" / "main" / "scala-spark-3.5",
     Test / unmanagedSourceDirectories += (Compile / baseDirectory).value / "src" / "test" / "scala-spark-3.5",
     Antlr4 / antlr4Version := "4.9.3",
-
-    // Java-/Scala-/Uni-Doc Settings
-    scalacOptions ++= Seq(
-      "-P:genjavadoc:strictVisibility=true" // hide package private types and methods in javadoc
-    ),
-    unidocSourceFilePatterns := Seq(SourceFilePattern("io/delta/tables/", "io/delta/exceptions/"))
   )
 
   case SPARK_MASTER_VERSION => Seq(
@@ -170,13 +185,6 @@ def crossSparkSettings(): Seq[Setting[_]] = getSparkVersion() match {
       "--add-opens=java.base/sun.security.action=ALL-UNNAMED",
       "--add-opens=java.base/sun.util.calendar=ALL-UNNAMED"
     )
-
-    // Java-/Scala-/Uni-Doc Settings
-    // This isn't working yet against Spark Master.
-    // 1) delta-spark on Spark Master uses JDK 17. delta-iceberg uses JDK 8 or 11. For some reason,
-    //    generating delta-spark unidoc compiles delta-iceberg
-    // 2) delta-spark unidoc fails to compile. spark 3.5 is on its classpath. likely due to iceberg
-    //    issue above.
   )
 }
 
@@ -190,6 +198,7 @@ lazy val spark = (project in file("spark"))
     sparkMimaSettings,
     releaseSettings,
     crossSparkSettings(),
+    crossSparkProjectSettings(),
     libraryDependencies ++= Seq(
       // Adding test classifier seems to break transitive resolution of the core dependencies
       "org.apache.spark" %% "spark-hive" % sparkVersion.value % "provided",
@@ -357,6 +366,7 @@ lazy val kernelDefaults = (project in file("kernel/kernel-defaults"))
     scalaStyleSettings,
     javaOnlyReleaseSettings,
     Test / javaOptions ++= Seq("-ea"),
+    crossSparkSettings(),
     libraryDependencies ++= Seq(
       "org.apache.hadoop" % "hadoop-client-runtime" % hadoopVersion,
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.5",
@@ -373,10 +383,10 @@ lazy val kernelDefaults = (project in file("kernel/kernel-defaults"))
       "org.openjdk.jmh" % "jmh-core" % "1.37" % "test",
       "org.openjdk.jmh" % "jmh-generator-annprocess" % "1.37" % "test",
 
-      "org.apache.spark" %% "spark-hive" % defaultSparkVersion % "test" classifier "tests",
-      "org.apache.spark" %% "spark-sql" % defaultSparkVersion % "test" classifier "tests",
-      "org.apache.spark" %% "spark-core" % defaultSparkVersion % "test" classifier "tests",
-      "org.apache.spark" %% "spark-catalyst" % defaultSparkVersion % "test" classifier "tests",
+      "org.apache.spark" %% "spark-hive" % sparkVersion.value % "test" classifier "tests",
+      "org.apache.spark" %% "spark-sql" % sparkVersion.value % "test" classifier "tests",
+      "org.apache.spark" %% "spark-core" % sparkVersion.value % "test" classifier "tests",
+      "org.apache.spark" %% "spark-catalyst" % sparkVersion.value % "test" classifier "tests",
     ),
     javaCheckstyleSettings("kernel/dev/checkstyle.xml"),
       // Unidoc settings
@@ -1071,14 +1081,15 @@ lazy val goldenTables = (project in file("connectors/golden-tables"))
     name := "golden-tables",
     commonSettings,
     skipReleaseSettings,
+    crossSparkSettings(),
     libraryDependencies ++= Seq(
       // Test Dependencies
       "org.scalatest" %% "scalatest" % scalaTestVersion % "test",
       "commons-io" % "commons-io" % "2.8.0" % "test",
-      "org.apache.spark" %% "spark-sql" % defaultSparkVersion % "test",
-      "org.apache.spark" %% "spark-catalyst" % defaultSparkVersion % "test" classifier "tests",
-      "org.apache.spark" %% "spark-core" % defaultSparkVersion % "test" classifier "tests",
-      "org.apache.spark" %% "spark-sql" % defaultSparkVersion % "test" classifier "tests"
+      "org.apache.spark" %% "spark-sql" % sparkVersion.value % "test",
+      "org.apache.spark" %% "spark-catalyst" % sparkVersion.value % "test" classifier "tests",
+      "org.apache.spark" %% "spark-core" % sparkVersion.value % "test" classifier "tests",
+      "org.apache.spark" %% "spark-sql" % sparkVersion.value % "test" classifier "tests"
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -138,6 +138,7 @@ def crossSparkSettings(): Seq[Setting[_]] = getSparkVersion() match {
     // For adding staged Spark RC versions, e.g.:
     // resolvers += "Apache Spark 3.5.0 (RC1) Staging" at "https://repository.apache.org/content/repositories/orgapachespark-1444/",
     Compile / unmanagedSourceDirectories += (Compile / baseDirectory).value / "src" / "main" / "scala-spark-3.5",
+    Test / unmanagedSourceDirectories += (Compile / baseDirectory).value / "src" / "test" / "scala-spark-3.5",
     Antlr4 / antlr4Version := "4.9.3",
 
     // Java-/Scala-/Uni-Doc Settings
@@ -153,6 +154,7 @@ def crossSparkSettings(): Seq[Setting[_]] = getSparkVersion() match {
     targetJvm := "17",
     resolvers += "Spark master staging" at "https://repository.apache.org/content/groups/snapshots/",
     Compile / unmanagedSourceDirectories += (Compile / baseDirectory).value / "src" / "main" / "scala-spark-master",
+    Test / unmanagedSourceDirectories += (Compile / baseDirectory).value / "src" / "test" / "scala-spark-master",
     Antlr4 / antlr4Version := "4.13.1",
     Test / javaOptions ++= Seq(
       // Copied from SparkBuild.scala to support Java 17 for unit tests (see apache/spark#34153)

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/ScanBuilder.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/ScanBuilder.java
@@ -19,6 +19,7 @@ package io.delta.kernel;
 import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.client.TableClient;
 import io.delta.kernel.expressions.Predicate;
+import io.delta.kernel.types.DataType;
 import io.delta.kernel.types.StructType;
 
 /**
@@ -48,6 +49,12 @@ public interface ScanBuilder {
      * @return A {@link ScanBuilder} with projection pruning.
      */
     ScanBuilder withReadSchema(TableClient tableClient, StructType readSchema);
+
+    ScanBuilder withExtractedVariantField(
+            TableClient tableClient,
+            String path,
+            DataType type,
+            String extractedFieldName);
 
     /**
      * @return Build the {@link Scan instance}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/data/ColumnVector.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/data/ColumnVector.java
@@ -176,6 +176,14 @@ public interface ColumnVector extends AutoCloseable {
     }
 
     /**
+     * Return the variant value located at {@code rowId}. Returns null if the slot for {@code rowId}
+     * is null
+     */
+    default VariantValue getVariant(int rowId) {
+        throw new UnsupportedOperationException("Invalid value request for data type");
+    }
+
+    /**
      * Get the child vector associated with the given ordinal. This method is applicable only to the
      * {@code struct} type columns.
      *

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/data/Row.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/data/Row.java
@@ -117,4 +117,10 @@ public interface Row {
      * Throws error if the column at given ordinal is not of map type,
      */
     MapValue getMap(int ordinal);
+
+    /**
+     * Return variant value of the column located at the given ordinal.
+     * Throws error if the column at given ordinal is not of variant type.
+     */
+    VariantValue getVariant(int ordinal);
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/data/VariantValue.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/data/VariantValue.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.data;
+
+/**
+ * Abstraction to represent a single Variant value in a {@link ColumnVector}.
+ */
+public interface VariantValue {
+    byte[] getValue();
+
+    byte[] getMetadata();
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ExtractedVariantOptions.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ExtractedVariantOptions.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.internal;
+
+import io.delta.kernel.expressions.Column;
+import io.delta.kernel.types.DataType;
+
+public class ExtractedVariantOptions {
+    public Column path;
+    public String fieldName;
+    public DataType type;
+
+    public ExtractedVariantOptions(Column path, DataType type, String fieldName) {
+        this.path = path;
+        this.fieldName = fieldName;
+        this.type = type;
+    }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
@@ -58,6 +58,7 @@ public class ScanImpl implements Scan {
     private final LogReplay logReplay;
     private final Path dataPath;
     private final Optional<Tuple2<Predicate, Predicate>> partitionAndDataFilters;
+    private final List<ExtractedVariantOptions> extractedVariantFields;
     private final Supplier<Map<String, StructField>> partitionColToStructFieldMap;
     private boolean accessedScanFiles;
 
@@ -68,6 +69,7 @@ public class ScanImpl implements Scan {
             Metadata metadata,
             LogReplay logReplay,
             Optional<Predicate> filter,
+            List<ExtractedVariantOptions> extractedVariantFields,
             Path dataPath) {
         this.snapshotSchema = snapshotSchema;
         this.readSchema = readSchema;
@@ -85,6 +87,7 @@ public class ScanImpl implements Scan {
                             field -> field.getName().toLowerCase(Locale.ROOT),
                             identity()));
         };
+        this.extractedVariantFields = extractedVariantFields;
     }
 
     /**
@@ -157,7 +160,8 @@ public class ScanImpl implements Scan {
             readSchema.toJson(),
             physicalReadSchema.toJson(),
             physicalDataReadSchema.toJson(),
-            dataPath.toUri().toString());
+            dataPath.toUri().toString(),
+            extractedVariantFields);
     }
 
     @Override

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableFeatures.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableFeatures.java
@@ -46,6 +46,7 @@ public class TableFeatures {
                             break;
                         case "deletionVectors": // fall through
                         case "timestampNtz": // fall through
+                        case "variantType-dev":
                         case "vacuumProtocolCheck":
                             break;
                         default:

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/ChildVectorBasedRow.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/ChildVectorBasedRow.java
@@ -21,6 +21,7 @@ import io.delta.kernel.data.ArrayValue;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.MapValue;
 import io.delta.kernel.data.Row;
+import io.delta.kernel.data.VariantValue;
 import io.delta.kernel.types.StructType;
 
 /**
@@ -109,6 +110,11 @@ public abstract class ChildVectorBasedRow implements Row {
     @Override
     public MapValue getMap(int ordinal) {
         return getChild(ordinal).getMap(rowId);
+    }
+
+    @Override
+    public VariantValue getVariant(int ordinal) {
+        return getChild(ordinal).getVariant(rowId);
     }
 
     protected abstract ColumnVector getChild(int ordinal);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/GenericRow.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/GenericRow.java
@@ -137,7 +137,6 @@ public class GenericRow implements Row {
 
     @Override
     public VariantValue getVariant(int ordinal) {
-        // TODO(r.chen): test this path somehow?
         throwIfUnsafeAccess(ordinal, VariantType.class, "variant");
         return (VariantValue) getValue(ordinal);
     }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/GenericRow.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/GenericRow.java
@@ -141,7 +141,8 @@ public class GenericRow implements Row {
         return (VariantValue) getValue(ordinal);
     }
 
-    private Object getValue(int ordinal) {
+    // TODO: HACK to not have to serialize and deserialize the ExtractedVarinatOptions list.
+    public Object getValue(int ordinal) {
         return ordinalToValue.get(ordinal);
     }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/GenericRow.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/GenericRow.java
@@ -23,6 +23,7 @@ import static java.util.Objects.requireNonNull;
 import io.delta.kernel.data.ArrayValue;
 import io.delta.kernel.data.MapValue;
 import io.delta.kernel.data.Row;
+import io.delta.kernel.data.VariantValue;
 import io.delta.kernel.types.*;
 
 /**
@@ -132,6 +133,13 @@ public class GenericRow implements Row {
         // TODO: not sufficient check, also need to check the element types
         throwIfUnsafeAccess(ordinal, MapType.class, "map");
         return (MapValue) getValue(ordinal);
+    }
+
+    @Override
+    public VariantValue getVariant(int ordinal) {
+        // TODO(r.chen): test this path somehow?
+        throwIfUnsafeAccess(ordinal, VariantType.class, "variant");
+        return (VariantValue) getValue(ordinal);
     }
 
     private Object getValue(int ordinal) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/VariantUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/VariantUtils.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.internal.util;
+
+import java.util.Arrays;
+import java.util.List;
+
+import io.delta.kernel.client.ExpressionHandler;
+import io.delta.kernel.data.ColumnVector;
+import io.delta.kernel.data.ColumnarBatch;
+import io.delta.kernel.expressions.*;
+import io.delta.kernel.types.*;
+
+import io.delta.kernel.internal.ExtractedVariantOptions;
+
+/**
+ * Doc comment
+ */
+public class VariantUtils {
+
+    /**
+     * Doc comment
+     */
+    public static ColumnarBatch withExtractedVariantFields(
+            ExpressionHandler expressionHandler,
+            ColumnarBatch dataBatch,
+            List<ExtractedVariantOptions> extractedVariantFields) {
+        for (ExtractedVariantOptions opts : extractedVariantFields) {
+            // TODO: how does this work with column mapping? We're searching for the fieldName in
+            // the delta schema
+            String varColName = opts.path.getNames()[0];
+            int colIdx = dataBatch.getSchema().indexOf(varColName);
+            if (colIdx == -1) {
+                System.out.println("TOP LEVEL VARIANT IS NOT FOUND IN SCHEMA");
+                assert false;
+            }
+
+            ExpressionEvaluator evaluator = expressionHandler.getEvaluator(
+                getVariantGetExprSchema(varColName),
+                new ScalarExpression(
+                    "variant_get",
+                    Arrays.asList(
+                        new Column(varColName),
+                        Literal.ofString(String.join(".", opts.path.getNames())),
+                        // TODO: Does "toString" work on more complex types
+                        Literal.ofString(opts.type.toString()))
+                ),
+                opts.type
+            );
+
+            dataBatch = dataBatch.withNewColumn(
+                dataBatch.getSchema().length(),
+                // TODO: set this to the right datatype.
+                new StructField(opts.fieldName, StringType.STRING, true),
+                // TODO: we don't have to pass in the whole data batch, we only need the
+                // variant column.
+                extractVariantField(evaluator, dataBatch, opts)
+            );
+        }
+
+        return dataBatch;
+    }
+
+    private static ColumnVector extractVariantField(
+            ExpressionEvaluator evaluator,
+            ColumnarBatch batchWithVariantCol,
+            ExtractedVariantOptions options) {
+        return evaluator.eval(batchWithVariantCol);
+    }
+
+    private static StructType getVariantGetExprSchema(String variantColName) {
+        return new StructType()
+            .add(new StructField(variantColName, VariantType.VARIANT, true))
+            .add(new StructField("col_1", StringType.STRING, false))
+            .add(new StructField("col_2", StringType.STRING, false));
+    }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/VectorUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/VectorUtils.java
@@ -110,6 +110,8 @@ public final class VectorUtils {
             return toJavaList(columnVector.getArray(rowId));
         } else if (dataType instanceof MapType) {
             return toJavaMap(columnVector.getMap(rowId));
+        } else if (dataType instanceof VariantType) {
+            return columnVector.getVariant(rowId);
         } else {
             throw new UnsupportedOperationException("unsupported data type");
         }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/BasePrimitiveType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/BasePrimitiveType.java
@@ -64,6 +64,7 @@ public abstract class BasePrimitiveType extends DataType {
                 put("timestamp_ntz", TimestampNTZType.TIMESTAMP_NTZ);
                 put("binary", BinaryType.BINARY);
                 put("string", StringType.STRING);
+                put("variant", VariantType.VARIANT);
             }
         });
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructField.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructField.java
@@ -37,6 +37,8 @@ public class StructField {
      */
     private static String IS_METADATA_COLUMN_KEY = "isMetadataColumn";
 
+    private static String IS_INTERNALLY_ADDED_VARIANT = "isInternallyAddedVariant";
+
     /**
      * The name of a row index metadata column. When present this column must be populated with
      * row index of each row when reading from parquet.
@@ -47,6 +49,14 @@ public class StructField {
         LongType.LONG,
         false,
         FieldMetadata.builder().putBoolean(IS_METADATA_COLUMN_KEY, true).build());
+
+    public static StructField internallyAddedVariantSchema(String fieldName) {
+        return new StructField(
+            fieldName,
+            VariantType.VARIANT,
+            true,
+            FieldMetadata.builder().putBoolean(IS_INTERNALLY_ADDED_VARIANT, true).build());
+    }
 
 
     ////////////////////////////////////////////////////////////////////////////////
@@ -107,6 +117,11 @@ public class StructField {
     public boolean isMetadataColumn() {
         return metadata.contains(IS_METADATA_COLUMN_KEY) &&
             (boolean) metadata.get(IS_METADATA_COLUMN_KEY);
+    }
+
+    public boolean isInternallyAddedVariant() {
+        return metadata.contains(IS_INTERNALLY_ADDED_VARIANT) &&
+            (boolean) metadata.get(IS_INTERNALLY_ADDED_VARIANT);
     }
 
     public boolean isDataColumn() {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/VariantType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/VariantType.java
@@ -18,9 +18,7 @@ package io.delta.kernel.types;
 import io.delta.kernel.annotation.Evolving;
 
 /**
- * A variant type.
- * <p>
- * todo: more comments
+ * A logical variant type.
  * @since 4.0.0
  */
 @Evolving

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/VariantType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/VariantType.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.types;
+
+import io.delta.kernel.annotation.Evolving;
+
+/**
+ * A variant type.
+ * <p>
+ * todo: more comments
+ * @since 4.0.0
+ */
+@Evolving
+public class VariantType extends BasePrimitiveType {
+    public static final VariantType VARIANT = new VariantType();
+
+    private VariantType() {
+        super("variant");
+    }
+}

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
@@ -617,7 +617,7 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
     // corrupt incomplete multi-part checkpoint
     val corruptedCheckpointStatuses = FileNames.checkpointFileWithParts(logPath, 10, 5).asScala
       .map(p => FileStatus.of(p.toString, 10, 10))
-      .take(4)
+      .take(4).toSeq
     val deltas = deltaFileStatuses(10L to 13L)
     testExpectedError[RuntimeException](
       corruptedCheckpointStatuses ++ deltas,
@@ -666,7 +666,7 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
     // _last_checkpoint refers to incomplete multi-part checkpoint
     val corruptedCheckpointStatuses = FileNames.checkpointFileWithParts(logPath, 20, 5).asScala
       .map(p => FileStatus.of(p.toString, 10, 10))
-      .take(4)
+      .take(4).toSeq
     testExpectedError[RuntimeException](
       files = corruptedCheckpointStatuses ++ deltaFileStatuses(10L to 20L) ++
         singularCheckpointFileStatuses(Seq(10L)),

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/DefaultJsonRow.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/DefaultJsonRow.java
@@ -33,6 +33,7 @@ import io.delta.kernel.data.ArrayValue;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.MapValue;
 import io.delta.kernel.data.Row;
+import io.delta.kernel.data.VariantValue;
 import io.delta.kernel.types.*;
 import io.delta.kernel.internal.util.InternalUtils;
 
@@ -126,6 +127,11 @@ public class DefaultJsonRow implements Row {
     @Override
     public MapValue getMap(int ordinal) {
         return (MapValue) parsedValues[ordinal];
+    }
+
+    @Override
+    public VariantValue getVariant(int ordinal) {
+        throw new UnsupportedOperationException("not yet implemented");
     }
 
     private static void throwIfTypeMismatch(String expType, boolean hasExpType, JsonNode jsonNode) {

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/value/DefaultVariantValue.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/value/DefaultVariantValue.java
@@ -41,10 +41,12 @@ public class DefaultVariantValue implements VariantValue {
         return metadata;
     }
 
-    public String debugString() {
+    @Override
+    public String toString() {
         return "VariantValue{value=" + Arrays.toString(value) +
             ", metadata=" + Arrays.toString(metadata) + '}';
     }
+
     /**
      * Compare two variants in bytes. The variant equality is more complex than it, and we haven't
      * supported it in the user surface yet. This method is only intended for tests.

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/value/DefaultVariantValue.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/value/DefaultVariantValue.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.defaults.internal.data.value;
+
+import java.util.Arrays;
+
+import io.delta.kernel.data.VariantValue;
+
+/**
+ * Default implementation of a Delta kernel VariantValue.
+ */
+public class DefaultVariantValue implements VariantValue {
+    private final byte[] value;
+    private final byte[] metadata;
+
+    public DefaultVariantValue(byte[] value, byte[] metadata) {
+        this.value = value;
+        this.metadata = metadata;
+    }
+
+    @Override
+    public byte[] getValue() {
+        return value;
+    }
+
+    @Override
+    public byte[] getMetadata() {
+        return metadata;
+    }
+
+    public String debugString() {
+        return "VariantValue{value=" + Arrays.toString(value) +
+            ", metadata=" + Arrays.toString(metadata) + '}';
+    }
+    /**
+     * Compare two variants in bytes. The variant equality is more complex than it, and we haven't
+     * supported it in the user surface yet. This method is only intended for tests.
+     */
+    @Override
+    public boolean equals(Object other) {
+        if (other instanceof DefaultVariantValue) {
+            return Arrays.equals(value, ((DefaultVariantValue) other).getValue()) &&
+                Arrays.equals(metadata, ((DefaultVariantValue) other).getMetadata());
+        } else {
+            return false;
+        }
+    }
+}

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/AbstractColumnVector.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/AbstractColumnVector.java
@@ -22,6 +22,7 @@ import static java.util.Objects.requireNonNull;
 import io.delta.kernel.data.ArrayValue;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.MapValue;
+import io.delta.kernel.data.VariantValue;
 import io.delta.kernel.types.DataType;
 
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
@@ -136,6 +137,11 @@ public abstract class AbstractColumnVector
     @Override
     public ArrayValue getArray(int rowId) {
         throw unsupportedDataAccessException("array");
+    }
+
+    @Override
+    public VariantValue getVariant(int rowId) {
+        throw unsupportedDataAccessException("variant");
     }
 
     // TODO no need to override these here; update default implementations in `ColumnVector`

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/DefaultGenericVector.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/DefaultGenericVector.java
@@ -172,6 +172,13 @@ public class DefaultGenericVector implements ColumnVector {
                 (rowId) -> (Row) rowIdToValueAccessor.apply(rowId));
     }
 
+    @Override
+    public VariantValue getVariant(int rowId) {
+        assertValidRowId(rowId);
+        throwIfUnsafeAccess(VariantType.class, "variant");
+        return (VariantValue) rowIdToValueAccessor.apply(rowId);
+    }
+
     private void throwIfUnsafeAccess( Class<? extends DataType> expDataType, String accessType) {
         if (!expDataType.isAssignableFrom(dataType.getClass())) {
             String msg = String.format(

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/DefaultSubFieldVector.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/DefaultSubFieldVector.java
@@ -23,6 +23,7 @@ import io.delta.kernel.data.ArrayValue;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.MapValue;
 import io.delta.kernel.data.Row;
+import io.delta.kernel.data.VariantValue;
 import io.delta.kernel.types.DataType;
 import io.delta.kernel.types.StructField;
 import io.delta.kernel.types.StructType;
@@ -153,6 +154,12 @@ public class DefaultSubFieldVector implements ColumnVector {
     public ArrayValue getArray(int rowId) {
         assertValidRowId(rowId);
         return rowIdToRowAccessor.apply(rowId).getArray(columnOrdinal);
+    }
+
+    @Override
+    public VariantValue getVariant(int rowId) {
+        assertValidRowId(rowId);
+        return rowIdToRowAccessor.apply(rowId).getVariant(columnOrdinal);
     }
 
     @Override

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/DefaultVariantVector.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/DefaultVariantVector.java
@@ -37,12 +37,12 @@ public class DefaultVariantVector
      * Create an instance of {@link io.delta.kernel.data.ColumnVector} for array type.
      *
      * @param size          number of elements in the vector.
+     * @param type          {@code variant} datatype definition.
      * @param nullability   Optional array of nullability value for each element in the vector.
      *                      All values in the vector are considered non-null when parameter is
      *                      empty.
-     * @param offsets       Offsets into element vector on where the index of particular row
-     *                      values start and end.
-     * @param elementVector Vector containing the array elements.
+     * @param value         The child binary column vector representing each variant's values.
+     * @param metadata         The child binary column vector representing each variant's metadata.
      */
     public DefaultVariantVector(
         int size,
@@ -84,6 +84,13 @@ public class DefaultVariantVector
         };
     }
 
+    /**
+     * Get the child column vector at the given {@code ordinal}. Variants should only have two
+     * child vectors, one for value and one for metadata.
+     *
+     * @param ordinal
+     * @return
+     */
     @Override
     public ColumnVector getChild(int ordinal) {
         checkArgument(ordinal >= 0 && ordinal < 2, "Invalid ordinal " + ordinal);

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/DefaultVariantVector.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/DefaultVariantVector.java
@@ -23,6 +23,7 @@ import io.delta.kernel.data.VariantValue;
 import io.delta.kernel.types.DataType;
 
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
+import io.delta.kernel.defaults.internal.data.value.DefaultVariantValue;
 
 /**
  * {@link io.delta.kernel.data.ColumnVector} implementation for variant type data.
@@ -68,20 +69,22 @@ public class DefaultVariantVector
         if (isNullAt(rowId)) {
             return null;
         }
-        return new VariantValue() {
-            private final byte[] value = valueVector.getBinary(rowId);
-            private final byte[] metadata = metadataVector.getBinary(rowId);
+        // return new VariantValue() {
+        //     private final byte[] value = valueVector.getBinary(rowId);
+        //     private final byte[] metadata = metadataVector.getBinary(rowId);
 
-            @Override
-            public byte[] getValue() {
-                return value;
-            }
+        //     @Override
+        //     public byte[] getValue() {
+        //         return value;
+        //     }
 
-            @Override
-            public byte[] getMetadata() {
-                return metadata;
-            }
-        };
+        //     @Override
+        //     public byte[] getMetadata() {
+        //         return metadata;
+        //     }
+        // };
+        return new DefaultVariantValue(
+            valueVector.getBinary(rowId), metadataVector.getBinary(rowId));
     }
 
     /**

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/DefaultVariantVector.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/DefaultVariantVector.java
@@ -22,6 +22,8 @@ import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.VariantValue;
 import io.delta.kernel.types.DataType;
 
+import static io.delta.kernel.internal.util.Preconditions.checkArgument;
+
 /**
  * {@link io.delta.kernel.data.ColumnVector} implementation for variant type data.
  */

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/DefaultVariantVector.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/DefaultVariantVector.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.defaults.internal.data.vector;
+
+import java.util.Optional;
+import static java.util.Objects.requireNonNull;
+
+import io.delta.kernel.data.ColumnVector;
+import io.delta.kernel.data.VariantValue;
+import io.delta.kernel.types.DataType;
+
+/**
+ * {@link io.delta.kernel.data.ColumnVector} implementation for variant type data.
+ */
+public class DefaultVariantVector
+    extends AbstractColumnVector {
+    private final ColumnVector valueVector;
+    private final ColumnVector metadataVector;
+
+
+    /**
+     * Create an instance of {@link io.delta.kernel.data.ColumnVector} for array type.
+     *
+     * @param size          number of elements in the vector.
+     * @param nullability   Optional array of nullability value for each element in the vector.
+     *                      All values in the vector are considered non-null when parameter is
+     *                      empty.
+     * @param offsets       Offsets into element vector on where the index of particular row
+     *                      values start and end.
+     * @param elementVector Vector containing the array elements.
+     */
+    public DefaultVariantVector(
+        int size,
+        DataType type,
+        Optional<boolean[]> nullability,
+        ColumnVector value,
+        ColumnVector metadata) {
+        super(size, type, nullability);
+        // checkArgument(offsets.length >= size + 1, "invalid offset array size");
+        this.valueVector = requireNonNull(value, "value is null");
+        this.metadataVector = requireNonNull(metadata, "metadata is null");
+    }
+
+    /**
+     * Get the value at given {@code rowId}. The return value is undefined and can be
+     * anything, if the slot for {@code rowId} is null.
+     *
+     * @param rowId
+     * @return
+     */
+    @Override
+    public VariantValue getVariant(int rowId) {
+        checkValidRowId(rowId);
+        if (isNullAt(rowId)) {
+            return null;
+        }
+        return new VariantValue() {
+            private final byte[] value = valueVector.getBinary(rowId);
+            private final byte[] metadata = metadataVector.getBinary(rowId);
+
+            @Override
+            public byte[] getValue() {
+                return value;
+            }
+
+            @Override
+            public byte[] getMetadata() {
+                return metadata;
+            }
+        };
+    }
+
+    public ColumnVector getValueVector() {
+        return valueVector;
+    }
+
+    public ColumnVector getMetadataVector() {
+        return metadataVector;
+    }
+}

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/DefaultVariantVector.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/DefaultVariantVector.java
@@ -82,11 +82,13 @@ public class DefaultVariantVector
         };
     }
 
-    public ColumnVector getValueVector() {
-        return valueVector;
-    }
-
-    public ColumnVector getMetadataVector() {
-        return metadataVector;
+    @Override
+    public ColumnVector getChild(int ordinal) {
+        checkArgument(ordinal >= 0 && ordinal < 2, "Invalid ordinal " + ordinal);
+        if (ordinal == 0) {
+            return valueVector;
+        } else {
+            return metadataVector;
+        }
     }
 }

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/DefaultVariantVector.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/DefaultVariantVector.java
@@ -69,20 +69,7 @@ public class DefaultVariantVector
         if (isNullAt(rowId)) {
             return null;
         }
-        // return new VariantValue() {
-        //     private final byte[] value = valueVector.getBinary(rowId);
-        //     private final byte[] metadata = metadataVector.getBinary(rowId);
 
-        //     @Override
-        //     public byte[] getValue() {
-        //         return value;
-        //     }
-
-        //     @Override
-        //     public byte[] getMetadata() {
-        //         return metadata;
-        //     }
-        // };
         return new DefaultVariantValue(
             valueVector.getBinary(rowId), metadataVector.getBinary(rowId));
     }

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/DefaultVariantVector.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/DefaultVariantVector.java
@@ -49,7 +49,6 @@ public class DefaultVariantVector
         ColumnVector value,
         ColumnVector metadata) {
         super(size, type, nullability);
-        // checkArgument(offsets.length >= size + 1, "invalid offset array size");
         this.valueVector = requireNonNull(value, "value is null");
         this.metadataVector = requireNonNull(metadata, "metadata is null");
     }

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/DefaultViewVector.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/DefaultViewVector.java
@@ -20,6 +20,7 @@ import java.math.BigDecimal;
 import io.delta.kernel.data.ArrayValue;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.MapValue;
+import io.delta.kernel.data.VariantValue;
 import io.delta.kernel.types.DataType;
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 
@@ -135,6 +136,12 @@ public class DefaultViewVector implements ColumnVector {
     public ArrayValue getArray(int rowId) {
         checkValidRowId(rowId);
         return underlyingVector.getArray(offset + rowId);
+    }
+
+    @Override
+    public VariantValue getVariant(int rowId) {
+        checkValidRowId(rowId);
+        return underlyingVector.getVariant(offset + rowId);
     }
 
     @Override

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
@@ -15,6 +15,7 @@
  */
 package io.delta.kernel.defaults.internal.expressions;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -276,6 +277,21 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
                         .collect(Collectors.toList())),
                 children.get(0).outputType
             );
+        }
+
+        @Override
+        ExpressionTransformResult visitVariantGet(ScalarExpression variantGet) {
+            Expression transformedVariantInput = visit(childAt(variantGet, 0)).expression;
+            Expression transformedPath = visit(childAt(variantGet, 1)).expression;
+            Expression transformedType = visit(childAt(variantGet, 2)).expression;
+
+            // TODO: actually finish this. Do validations and cast anything if necessary.
+            return new ExpressionTransformResult(
+                new ScalarExpression(
+                    "VARIANT_GET",
+                    Arrays.asList(transformedVariantInput, transformedPath, transformedType)),
+                // TODO Hardcoded to string type output
+                StringType.STRING);
         }
 
         private Predicate validateIsPredicate(
@@ -556,6 +572,16 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
                     return 0; // If all are null then any idx suffices
                 }
             );
+        }
+
+        @Override
+        ColumnVector visitVariantGet(ScalarExpression variantGet) {
+            ColumnVector variantResult = visit(childAt(variantGet, 0));
+            ColumnVector pathResult = visit(childAt(variantGet, 1));
+            ColumnVector dataTypeResult = visit(childAt(variantGet, 2));
+
+            // TODO: actually implement variant_get rather than returning the path.
+            return pathResult;
         }
 
         /**

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ExpressionVisitor.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ExpressionVisitor.java
@@ -59,6 +59,8 @@ abstract class ExpressionVisitor<R> {
 
     abstract R visitCoalesce(ScalarExpression ifNull);
 
+    abstract R visitVariantGet(ScalarExpression variantGet);
+
     final R visit(Expression expression) {
         if (expression instanceof PartitionValueExpression) {
             return visitPartitionValue((PartitionValueExpression) expression);
@@ -105,6 +107,8 @@ abstract class ExpressionVisitor<R> {
                 return visitIsNull(new Predicate(name, children));
             case "COALESCE":
                 return visitCoalesce(expression);
+            case "VARIANT_GET":
+                return visitVariantGet(expression);
             default:
                 throw new UnsupportedOperationException(
                     String.format("Scalar expression `%s` is not supported.", name));

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetColumnReaders.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetColumnReaders.java
@@ -83,7 +83,7 @@ class ParquetColumnReaders {
         } else if (typeFromClient instanceof TimestampNTZType) {
             return createTimestampNtzConverter(initialBatchSize, typeFromFile);
         } else if (typeFromClient instanceof VariantType) {
-            return new VariantConverter(initialBatchSize);
+            return new VariantColumnReader(initialBatchSize);
         }
 
         throw new UnsupportedOperationException(typeFromClient + " is not supported");

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetColumnReaders.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetColumnReaders.java
@@ -82,6 +82,8 @@ class ParquetColumnReaders {
             return createTimestampConverter(initialBatchSize, typeFromFile);
         } else if (typeFromClient instanceof TimestampNTZType) {
             return createTimestampNtzConverter(initialBatchSize, typeFromFile);
+        } else if (typeFromClient instanceof VariantType) {
+            return new VariantConverter(initialBatchSize);
         }
 
         throw new UnsupportedOperationException(typeFromClient + " is not supported");

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetColumnReaders.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetColumnReaders.java
@@ -83,6 +83,8 @@ class ParquetColumnReaders {
         } else if (typeFromClient instanceof TimestampNTZType) {
             return createTimestampNtzConverter(initialBatchSize, typeFromFile);
         } else if (typeFromClient instanceof VariantType) {
+            // TODO: When shredding happens, we need to pass in the `typeFromFile` to read the
+            // shredded paths.
             return new VariantColumnReader(initialBatchSize);
         }
 

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetSchemaUtils.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetSchemaUtils.java
@@ -235,6 +235,8 @@ class ParquetSchemaUtils {
             type = toParquetMapType((MapType) dataType, name, repetition);
         } else if (dataType instanceof StructType) {
             type = toParquetStructType((StructType) dataType, name, repetition);
+        } else if (dataType instanceof VariantType) {
+            type = toParquetVariantType((VariantType) dataType, name, repetition);
         } else {
             throw new UnsupportedOperationException(
                     "Writing given type data to Parquet is not supported: " + dataType);
@@ -293,6 +295,15 @@ class ParquetSchemaUtils {
                     field.isNullable() ? OPTIONAL : REQUIRED,
                     getFieldId(field)));
         }
+        return new GroupType(repetition, name, fields);
+    }
+
+    private static Type toParquetVariantType(VariantType structType, String name,
+                                             Repetition repetition) {
+        List<Type> fields = Arrays.asList(
+            toParquetType(BinaryType.BINARY, "value", REQUIRED, Optional.empty()),
+            toParquetType(BinaryType.BINARY, "metadata", REQUIRED, Optional.empty())
+        );
         return new GroupType(repetition, name, fields);
     }
 

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetSchemaUtils.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetSchemaUtils.java
@@ -236,7 +236,7 @@ class ParquetSchemaUtils {
         } else if (dataType instanceof StructType) {
             type = toParquetStructType((StructType) dataType, name, repetition);
         } else if (dataType instanceof VariantType) {
-            type = toParquetVariantType((VariantType) dataType, name, repetition);
+            type = toParquetVariantType(name, repetition);
         } else {
             throw new UnsupportedOperationException(
                     "Writing given type data to Parquet is not supported: " + dataType);
@@ -298,13 +298,11 @@ class ParquetSchemaUtils {
         return new GroupType(repetition, name, fields);
     }
 
-    private static Type toParquetVariantType(VariantType structType, String name,
-                                             Repetition repetition) {
-        List<Type> fields = Arrays.asList(
-            toParquetType(BinaryType.BINARY, "value", REQUIRED, Optional.empty()),
-            toParquetType(BinaryType.BINARY, "metadata", REQUIRED, Optional.empty())
-        );
-        return new GroupType(repetition, name, fields);
+    private static Type toParquetVariantType(String name, Repetition repetition) {
+        return Types.buildGroup(repetition)
+          .addField(toParquetType(BinaryType.BINARY, "value", REQUIRED, Optional.empty()))
+          .addField(toParquetType(BinaryType.BINARY, "metadata", REQUIRED, Optional.empty()))
+          .named(name);
     }
 
     /**

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/VariantConverter.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/VariantConverter.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.defaults.internal.parquet;
+
+import java.util.*;
+
+import org.apache.parquet.io.api.Converter;
+import org.apache.parquet.io.api.GroupConverter;
+
+import io.delta.kernel.data.ColumnVector;
+import io.delta.kernel.types.BinaryType;
+import io.delta.kernel.types.VariantType;
+import static io.delta.kernel.internal.util.Preconditions.checkArgument;
+
+import io.delta.kernel.defaults.internal.data.vector.DefaultVariantVector;
+import io.delta.kernel.defaults.internal.parquet.ParquetConverters.BinaryColumnConverter;
+
+class VariantConverter
+    extends GroupConverter
+    implements ParquetConverters.BaseConverter {
+    private final BinaryColumnConverter valueConverter;
+    private final BinaryColumnConverter metadataConverter;
+
+    // Working state
+    private boolean isCurrentValueNull = true;
+    private int currentRowIndex;
+    private boolean[] nullability;
+
+    /**
+     * Create converter for {@link VariantType} column.
+     *
+     * @param initialBatchSize Estimate of initial row batch size. Used in memory allocations.
+     */
+    VariantConverter(int initialBatchSize) {
+        checkArgument(initialBatchSize > 0, "invalid initialBatchSize: %s", initialBatchSize);
+        // Initialize the working state
+        this.nullability = ParquetConverters.initNullabilityVector(initialBatchSize);
+
+        int parquetOrdinal = 0;
+        this.valueConverter = new BinaryColumnConverter(BinaryType.BINARY, initialBatchSize);
+        this.metadataConverter = new BinaryColumnConverter(BinaryType.BINARY, initialBatchSize);
+    }
+
+    @Override
+    public Converter getConverter(int fieldIndex) {
+        checkArgument(
+            fieldIndex >= 0 && fieldIndex < 2,
+            "variant type is represented by a struct with 2 fields");
+        if (fieldIndex == 0) {
+            return valueConverter;
+        } else {
+            return metadataConverter;
+        }
+    }
+
+    @Override
+    public void start() {
+        isCurrentValueNull = false;
+    }
+
+    @Override
+    public void end() {
+    }
+
+    @Override
+    public void finalizeCurrentRow(long currentRowIndex) {
+        resizeIfNeeded();
+        finalizeLastRowInConverters(currentRowIndex);
+        nullability[this.currentRowIndex] = isCurrentValueNull;
+        isCurrentValueNull = true;
+
+        this.currentRowIndex++;
+    }
+
+    public ColumnVector getDataColumnVector(int batchSize) {
+        ColumnVector vector = new DefaultVariantVector(
+            batchSize,
+            VariantType.VARIANT,
+            Optional.of(nullability),
+            valueConverter.getDataColumnVector(batchSize),
+            metadataConverter.getDataColumnVector(batchSize)
+        );
+        resetWorkingState();
+        return vector;
+    }
+
+    @Override
+    public void resizeIfNeeded() {
+        if (nullability.length == currentRowIndex) {
+            int newSize = nullability.length * 2;
+            this.nullability = Arrays.copyOf(this.nullability, newSize);
+            ParquetConverters.setNullabilityToTrue(this.nullability, newSize / 2, newSize);
+        }
+    }
+
+    @Override
+    public void resetWorkingState() {
+        this.currentRowIndex = 0;
+        this.isCurrentValueNull = true;
+        this.nullability = ParquetConverters.initNullabilityVector(this.nullability.length);
+    }
+
+    private void finalizeLastRowInConverters(long prevRowIndex) {
+        valueConverter.finalizeCurrentRow(prevRowIndex);
+        metadataConverter.finalizeCurrentRow(prevRowIndex);
+    }
+}

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/VariantConverter.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/VariantConverter.java
@@ -34,10 +34,12 @@ class VariantConverter
     private final BinaryColumnConverter valueConverter;
     private final BinaryColumnConverter metadataConverter;
 
-    // Working state
-    private boolean isCurrentValueNull = true;
+    // working state
     private int currentRowIndex;
     private boolean[] nullability;
+    // If the value is null, start/end never get called which is a signal for null
+    // Set the initial state to true and when start() is called set it to false.
+    private boolean isCurrentValueNull = true;
 
     /**
      * Create converter for {@link VariantType} column.
@@ -46,10 +48,8 @@ class VariantConverter
      */
     VariantConverter(int initialBatchSize) {
         checkArgument(initialBatchSize > 0, "invalid initialBatchSize: %s", initialBatchSize);
-        // Initialize the working state
         this.nullability = ParquetConverters.initNullabilityVector(initialBatchSize);
 
-        int parquetOrdinal = 0;
         this.valueConverter = new BinaryColumnConverter(BinaryType.BINARY, initialBatchSize);
         this.metadataConverter = new BinaryColumnConverter(BinaryType.BINARY, initialBatchSize);
     }

--- a/kernel/kernel-defaults/src/test/java/io/delta/kernel/defaults/integration/DataBuilderUtils.java
+++ b/kernel/kernel-defaults/src/test/java/io/delta/kernel/defaults/integration/DataBuilderUtils.java
@@ -26,6 +26,7 @@ import io.delta.kernel.data.ArrayValue;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.data.MapValue;
 import io.delta.kernel.data.Row;
+import io.delta.kernel.data.VariantValue;
 import io.delta.kernel.types.StructType;
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 
@@ -164,6 +165,11 @@ public class DataBuilderUtils {
         public MapValue getMap(int ordinal) {
             throw new UnsupportedOperationException(
                     "map type unsupported for TestColumnBatchBuilder; use scala test utilities");
+        }
+
+        @Override
+        public VariantValue getVariant(int ordinal) {
+            return (VariantValue) values.get(ordinal);
         }
     }
 }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
@@ -296,12 +296,12 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
       Seq(TestRow(2), TestRow(2), TestRow(2)),
       TestRow("2", "2", TestRow(2, 2L)),
       "2"
-    ) :: Nil)
+    ) :: Nil).toSeq
 
     checkTable(
       path = path,
       expectedAnswer = expectedAnswer,
-      readCols = readCols
+      readCols = readCols.toSeq
     )
   }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/LogReplayMetricsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/LogReplayMetricsSuite.scala
@@ -342,7 +342,7 @@ trait FileReadMetrics { self: Object =>
     }
   }
 
-  def getVersionsRead: Seq[Long] = versionsRead
+  def getVersionsRead: Seq[Long] = versionsRead.toSeq
 
   def resetMetrics(): Unit = {
     versionsRead.clear()

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetFileReaderSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetFileReaderSuite.scala
@@ -16,6 +16,9 @@
 package io.delta.kernel.defaults.internal.parquet
 
 import java.math.BigDecimal
+
+import org.apache.spark.sql.DataFrame
+
 import io.delta.golden.GoldenTableUtils.goldenTableFile
 import io.delta.kernel.defaults.utils.{ExpressionTestUtils, TestRow, VectorTestUtils}
 import io.delta.kernel.types._
@@ -139,4 +142,55 @@ class ParquetFileReaderSuite extends AnyFunSuite
 
     checkAnswer(actResult2, expResult2)
   }
+
+  private def testReadVariant(testName: String)(df: => DataFrame): Unit = {
+    test(testName) {
+      withTable("test_variant_table") {
+        df.write
+          .format("delta")
+          .mode("overwrite")
+          .saveAsTable("test_variant_table")
+        val path = spark.sql("describe table extended `test_variant_table`")
+          .where("col_name = 'Location'")
+          .collect()(0)
+          .getString(1)
+          .replace("file:", "")
+
+        val kernelSchema = tableSchema(path)
+        val actResult = readParquetFilesUsingKernel(path, kernelSchema)
+        val expResult = readParquetFilesUsingSpark(path, kernelSchema)
+        checkAnswer(actResult, expResult)
+      }
+    }
+  }
+
+  testReadVariant("basic read variant") {
+    spark.range(0, 10, 1, 1).selectExpr(
+      "parse_json(cast(id as string)) as basic_v",
+      "named_struct('v', parse_json(cast(id as string))) as struct_v",
+      """array(
+        parse_json(cast(id as string)),
+        parse_json(cast(id as string)),
+        parse_json(cast(id as string))
+      ) as array_v""",
+      "map('test', parse_json(cast(id as string))) as map_value_v",
+      "map(parse_json(cast(id as string)), parse_json(cast(id as string))) as map_key_v"
+    )
+  }
+
+  testReadVariant("basic null variant") {
+    spark.range(0, 10, 1, 1).selectExpr(
+      "cast(null as variant) basic_v",
+      "named_struct('v', cast(null as variant)) as struct_v",
+      """array(
+        parse_json(cast(id as string)),
+        parse_json(cast(id as string)),
+        null
+      ) as array_v""",
+      "map('test', cast(null as variant)) as map_value_v",
+      "map(cast(null as variant), parse_json(cast(id as string))) as map_key_v",
+    )
+  }
+
+  // TODO(richardc-db): Add nested variant tests once `parse_json` expression is implemented.
 }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetFileReaderSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetFileReaderSuite.scala
@@ -191,10 +191,7 @@ class ParquetFileReaderSuite extends AnyFunSuite
         parse_json(cast(id as string)),
         null
       ) as array_v""",
-      "map('test', cast(null as variant)) as map_value_v",
-      "map(cast(null as variant), parse_json(cast(id as string))) as map_key_v",
+      "map('test', cast(null as variant)) as map_value_v"
     )
   }
-
-  // TODO(richardc-db): Add nested variant tests once `parse_json` expression is implemented.
 }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetFileReaderSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetFileReaderSuite.scala
@@ -143,14 +143,18 @@ class ParquetFileReaderSuite extends AnyFunSuite
     checkAnswer(actResult2, expResult2)
   }
 
-  private def testReadVariant(testName: String)(df: => DataFrame): Unit = {
+  /**
+   * Writes a table using Spark, reads it back using the Delta Kernel implementation, and asserts
+   * that the results are the same.
+   */
+  private def testRead(testName: String)(df: => DataFrame): Unit = {
     test(testName) {
-      withTable("test_variant_table") {
+      withTable("test_table") {
         df.write
           .format("delta")
           .mode("overwrite")
-          .saveAsTable("test_variant_table")
-        val path = spark.sql("describe table extended `test_variant_table`")
+          .saveAsTable("test_table")
+        val path = spark.sql("describe table extended `test_table`")
           .where("col_name = 'Location'")
           .collect()(0)
           .getString(1)
@@ -164,7 +168,7 @@ class ParquetFileReaderSuite extends AnyFunSuite
     }
   }
 
-  testReadVariant("basic read variant") {
+  testRead("basic read variant") {
     spark.range(0, 10, 1, 1).selectExpr(
       "parse_json(cast(id as string)) as basic_v",
       "named_struct('v', parse_json(cast(id as string))) as struct_v",
@@ -178,7 +182,7 @@ class ParquetFileReaderSuite extends AnyFunSuite
     )
   }
 
-  testReadVariant("basic null variant") {
+  testRead("basic null variant") {
     spark.range(0, 10, 1, 1).selectExpr(
       "cast(null as variant) basic_v",
       "named_struct('v', cast(null as variant)) as struct_v",

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestRow.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestRow.scala
@@ -109,6 +109,7 @@ object TestRow {
         case _: ArrayType => arrayValueToScalaSeq(row.getArray(i))
         case _: MapType => mapValueToScalaMap(row.getMap(i))
         case _: StructType => TestRow(row.getStruct(i))
+        case _: VariantType => row.getVariant(i)
         case _ => throw new UnsupportedOperationException("unrecognized data type")
       }
     }.toSeq)
@@ -174,6 +175,7 @@ object TestRow {
             decodeCellValue(mapType.keyType, k) -> decodeCellValue(mapType.valueType, v)
           }
         case _: sparktypes.StructType => TestRow(row.getStruct(i))
+        case _: sparktypes.VariantType => row.getAs[Row](i)
         case _ => throw new UnsupportedOperationException("unrecognized data type")
       }
     })

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestRow.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestRow.scala
@@ -110,7 +110,7 @@ object TestRow {
         case _: StructType => TestRow(row.getStruct(i))
         case _ => throw new UnsupportedOperationException("unrecognized data type")
       }
-    })
+    }.toSeq)
   }
 
   def apply(row: SparkRow): TestRow = {

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestRow.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestRow.scala
@@ -16,6 +16,7 @@
 package io.delta.kernel.defaults.utils
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable.{Seq => MutableSeq}
 import org.apache.spark.sql.{types => sparktypes}
 import org.apache.spark.sql.{Row => SparkRow}
 import io.delta.kernel.data.{ArrayValue, ColumnVector, MapValue, Row}
@@ -133,7 +134,7 @@ object TestRow {
         case _: sparktypes.BinaryType => obj.asInstanceOf[Array[Byte]]
         case _: sparktypes.DecimalType => obj.asInstanceOf[java.math.BigDecimal]
         case arrayType: sparktypes.ArrayType =>
-          obj.asInstanceOf[Seq[Any]]
+          obj.asInstanceOf[MutableSeq[Any]]
             .map(decodeCellValue(arrayType.elementType, _))
         case mapType: sparktypes.MapType => obj.asInstanceOf[Map[Any, Any]].map {
           case (k, v) =>

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
@@ -41,7 +41,6 @@ import org.apache.hadoop.shaded.org.apache.commons.io.FileUtils
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.{types => sparktypes}
 import org.apache.spark.sql.catalyst.plans.SQLHelper
-import org.apache.spark.unsafe.types.VariantVal
 import org.scalatest.Assertions
 
 trait TestUtils extends Assertions with SQLHelper {
@@ -416,7 +415,6 @@ trait TestUtils extends Assertions with SQLHelper {
         java.lang.Double.doubleToRawLongBits(a) == java.lang.Double.doubleToRawLongBits(b)
       case (a: Float, b: Float) =>
         java.lang.Float.floatToRawIntBits(a) == java.lang.Float.floatToRawIntBits(b)
-      case (a: VariantVal, b: VariantVal) => a.debugString() == b.debugString()
       case (a, b) =>
         if (!a.equals(b)) {
           val sds = 200;

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
@@ -41,6 +41,7 @@ import org.apache.hadoop.shaded.org.apache.commons.io.FileUtils
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.{types => sparktypes}
 import org.apache.spark.sql.catalyst.plans.SQLHelper
+import org.apache.spark.unsafe.types.VariantVal
 import org.scalatest.Assertions
 
 trait TestUtils extends Assertions with SQLHelper {
@@ -115,6 +116,17 @@ trait TestUtils extends Assertions with SQLHelper {
 
   implicit object ResourceLoader {
     lazy val classLoader: ClassLoader = ResourceLoader.getClass.getClassLoader
+  }
+
+  /**
+   * Drops table `tableName` after calling `f`.
+   */
+  def withTable(tableNames: String*)(f: => Unit): Unit = {
+    try f finally {
+      tableNames.foreach { name =>
+        spark.sql(s"DROP TABLE IF EXISTS $name")
+      }
+    }
   }
 
   def withGoldenTable(tableName: String)(testFunc: String => Unit): Unit = {
@@ -404,6 +416,7 @@ trait TestUtils extends Assertions with SQLHelper {
         java.lang.Double.doubleToRawLongBits(a) == java.lang.Double.doubleToRawLongBits(b)
       case (a: Float, b: Float) =>
         java.lang.Float.floatToRawIntBits(a) == java.lang.Float.floatToRawIntBits(b)
+      case (a: VariantVal, b: VariantVal) => a.debugString() == b.debugString()
       case (a, b) =>
         if (!a.equals(b)) {
           val sds = 200;

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
@@ -73,7 +73,7 @@ trait TestUtils extends Assertions with SQLHelper {
         while (iter.hasNext) {
           result.append(iter.next())
         }
-        result
+        result.toSeq
       } finally {
         iter.close()
       }
@@ -153,7 +153,7 @@ trait TestUtils extends Assertions with SQLHelper {
         // for all primitive types
         Seq(new Column((basePath :+ field.getName).asJava.toArray(new Array[String](0))));
       case _ => Seq.empty
-    }
+    }.toSeq
   }
 
   def collectScanFileRows(scan: Scan, tableClient: TableClient = defaultTableClient): Seq[Row] = {
@@ -231,7 +231,7 @@ trait TestUtils extends Assertions with SQLHelper {
         }
       }
     }
-    result
+    result.toSeq
   }
 
   /**
@@ -626,7 +626,7 @@ trait TestUtils extends Assertions with SQLHelper {
             toSparkType(field.getDataType),
             field.isNullable
           )
-        })
+        }.toSeq)
     }
   }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
@@ -627,6 +627,7 @@ trait TestUtils extends Assertions with SQLHelper {
             field.isNullable
           )
         }.toSeq)
+      case VariantType.VARIANT => sparktypes.DataTypes.VariantType
     }
   }
 

--- a/spark/src/main/scala-spark-3.5/shims/VariantShim.scala
+++ b/spark/src/main/scala-spark-3.5/shims/VariantShim.scala
@@ -14,6 +14,13 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.delta
+package org.apache.spark.sql.types
 
-class DeltaVariantSuite extends DeltaVariantSparkOnlyTests
+object VariantShim {
+
+  /**
+   * Spark's variant type is implemented for Spark 4.0 and is not implemented in Spark 3.5. Thus,
+   * any Spark 3.5 DataType cannot be a variant type.
+   */
+  def isTypeVariant(dt: DataType): Boolean = false
+}

--- a/spark/src/main/scala-spark-master/shims/VariantShim.scala
+++ b/spark/src/main/scala-spark-master/shims/VariantShim.scala
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.delta
+package org.apache.spark.sql.types
 
-class DeltaVariantSuite extends DeltaVariantSparkOnlyTests
+object VariantShim {
+
+  /** Spark's variant type is only implemented in Spark 4.0 and above.*/
+  def isTypeVariant(dt: DataType): Boolean = dt.isInstanceOf[VariantType]
+}

--- a/spark/src/main/scala-spark-master/shims/VariantShim.scala
+++ b/spark/src/main/scala-spark-master/shims/VariantShim.scala
@@ -18,6 +18,6 @@ package org.apache.spark.sql.types
 
 object VariantShim {
 
-  /** Spark's variant type is only implemented in Spark 4.0 and above.*/
+  /** Spark's variant type is only implemented in Spark 4.0 and above. */
   def isTypeVariant(dt: DataType): Boolean = dt.isInstanceOf[VariantType]
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -359,7 +359,8 @@ object TableFeature {
         // managed-commits are under development and only available in testing.
         ManagedCommitTableFeature,
         InCommitTimestampTableFeature,
-        TypeWideningTableFeature)
+        TypeWideningTableFeature,
+        VariantTypeTableFeature)
     }
     val featureMap = features.map(f => f.name.toLowerCase(Locale.ROOT) -> f).toMap
     require(features.size == featureMap.size, "Lowercase feature names must not duplicate.")
@@ -491,6 +492,14 @@ object IdentityColumnsTableFeature
       metadata: Metadata,
       spark: SparkSession): Boolean = {
     ColumnWithDefaultExprUtils.hasIdentityColumn(metadata.schema)
+  }
+}
+
+object VariantTypeTableFeature extends ReaderWriterFeature(name = "variantType-dev")
+    with FeatureAutomaticallyEnabledByMetadata {
+  override def metadataRequiresFeatureToBeEnabled(
+      metadata: Metadata, spark: SparkSession): Boolean = {
+    SchemaUtils.checkForVariantTypeColumnsRecursively(metadata.schema)
   }
 }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
@@ -1267,7 +1267,7 @@ def normalizeColumnNamesInDataType(
    * Find VariantType columns in the table schema.
    */
   def checkForVariantTypeColumnsRecursively(schema: StructType): Boolean = {
-    SchemaUtils.typeExistsRecursively(schema)(_.isInstanceOf[VariantType])
+    SchemaUtils.typeExistsRecursively(schema)(VariantShim.isTypeVariant(_))
   }
 
   /**
@@ -1309,7 +1309,7 @@ def normalizeColumnNamesInDataType(
     case DateType =>
     case TimestampType =>
     case TimestampNTZType =>
-    case VariantType =>
+    case dt if VariantShim.isTypeVariant(dt) =>
     case BinaryType =>
     case _: DecimalType =>
     case a: ArrayType =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
@@ -1264,6 +1264,13 @@ def normalizeColumnNamesInDataType(
   }
 
   /**
+   * Find VariantType columns in the table schema.
+   */
+  def checkForVariantTypeColumnsRecursively(schema: StructType): Boolean = {
+    SchemaUtils.typeExistsRecursively(schema)(_.isInstanceOf[VariantType])
+  }
+
+  /**
    * Find TimestampNTZ columns in the table schema.
    */
   def checkForTimestampNTZColumnsRecursively(schema: StructType): Boolean = {
@@ -1302,6 +1309,7 @@ def normalizeColumnNamesInDataType(
     case DateType =>
     case TimestampType =>
     case TimestampNTZType =>
+    case VariantType =>
     case BinaryType =>
     case _: DecimalType =>
     case a: ArrayType =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/PartitionUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/PartitionUtils.scala
@@ -605,7 +605,7 @@ private[delta] object PartitionUtils {
 
     partitionColumnsSchema(schema, partitionColumns, caseSensitive).foreach {
       field => field.dataType match {
-        case _: AtomicType => // OK
+        case a: AtomicType if !a.isInstanceOf[VariantType] => // OK
         case _ => throw DeltaErrors.cannotUseDataTypeForPartitionColumnError(field)
       }
     }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/PartitionUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/PartitionUtils.scala
@@ -605,7 +605,7 @@ private[delta] object PartitionUtils {
 
     partitionColumnsSchema(schema, partitionColumns, caseSensitive).foreach {
       field => field.dataType match {
-        case a: AtomicType if !a.isInstanceOf[VariantType] => // OK
+        case a: AtomicType if !VariantShim.isTypeVariant(a) => // OK
         case _ => throw DeltaErrors.cannotUseDataTypeForPartitionColumnError(field)
       }
     }

--- a/spark/src/test/scala-spark-3.5/shims/DeltaVariantSparkOnlyTests.scala
+++ b/spark/src/test/scala-spark-3.5/shims/DeltaVariantSparkOnlyTests.scala
@@ -16,4 +16,4 @@
 
 package org.apache.spark.sql.delta
 
-class DeltaVariantSuite extends DeltaVariantSparkOnlyTests
+trait DeltaVariantSparkOnlyTests { self: DeltaVariantSuite => }

--- a/spark/src/test/scala-spark-master/shims/DeltaVariantSparkOnlyTests.scala
+++ b/spark/src/test/scala-spark-master/shims/DeltaVariantSparkOnlyTests.scala
@@ -1,0 +1,109 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.SparkThrowable
+import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.delta.actions.{Protocol, TableFeatureProtocolUtils}
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.types.StructType
+
+trait DeltaVariantSparkOnlyTests
+    extends QueryTest
+    with DeltaSQLCommandTest { self: DeltaVariantSuite =>
+  private def getProtocolForTable(table: String): Protocol = {
+    val deltaLog = DeltaLog.forTable(spark, TableIdentifier(table))
+    deltaLog.unsafeVolatileSnapshot.protocol
+  }
+
+  test("create a new table with Variant, higher protocol and feature should be picked.") {
+    withTable("tbl") {
+      sql("CREATE TABLE tbl(s STRING, v VARIANT) USING DELTA")
+      sql("INSERT INTO tbl (SELECT 'foo', parse_json(cast(id + 99 as string)) FROM range(1))")
+      assert(spark.table("tbl").selectExpr("v::int").head == Row(99))
+      assert(
+        getProtocolForTable("tbl") ==
+        VariantTypeTableFeature.minProtocolVersion.withFeature(VariantTypeTableFeature)
+      )
+    }
+  }
+
+  test("creating a table without Variant should use the usual minimum protocol") {
+    withTable("tbl") {
+      sql("CREATE TABLE tbl(s STRING, i INTEGER) USING DELTA")
+      assert(getProtocolForTable("tbl") == Protocol(1, 2))
+
+      val deltaLog = DeltaLog.forTable(spark, TableIdentifier("tbl"))
+      assert(
+        !deltaLog.unsafeVolatileSnapshot.protocol.isFeatureSupported(VariantTypeTableFeature),
+        s"Table tbl contains VariantTypeFeature descriptor when its not supposed to"
+      )
+    }
+  }
+
+  test("add a new Variant column should upgrade to the correct protocol versions") {
+    withTable("tbl") {
+      sql("CREATE TABLE tbl(s STRING) USING delta")
+      assert(getProtocolForTable("tbl") == Protocol(1, 2))
+
+      // Should throw error
+      val e = intercept[SparkThrowable] {
+        sql("ALTER TABLE tbl ADD COLUMN v VARIANT")
+      }
+      // capture the existing protocol here.
+      // we will check the error message later in this test as we need to compare the
+      // expected schema and protocol
+      val deltaLog = DeltaLog.forTable(spark, TableIdentifier("tbl"))
+      val currentProtocol = deltaLog.unsafeVolatileSnapshot.protocol
+      val currentFeatures = currentProtocol.implicitlyAndExplicitlySupportedFeatures
+        .map(_.name)
+        .toSeq
+        .sorted
+        .mkString(", ")
+
+      // add table feature
+      sql(
+        s"ALTER TABLE tbl " +
+        s"SET TBLPROPERTIES('delta.feature.variantType-dev' = 'supported')"
+      )
+
+      sql("ALTER TABLE tbl ADD COLUMN v VARIANT")
+
+      // check previously thrown error message
+      checkError(
+        e,
+        errorClass = "DELTA_FEATURES_REQUIRE_MANUAL_ENABLEMENT",
+        parameters = Map(
+          "unsupportedFeatures" -> VariantTypeTableFeature.name,
+          "supportedFeatures" -> currentFeatures
+        )
+      )
+
+      sql("INSERT INTO tbl (SELECT 'foo', parse_json(cast(id + 99 as string)) FROM range(1))")
+      assert(spark.table("tbl").selectExpr("v::int").head == Row(99))
+
+      assert(
+        getProtocolForTable("tbl") ==
+        VariantTypeTableFeature.minProtocolVersion
+          .withFeature(VariantTypeTableFeature)
+          .withFeature(InvariantsTableFeature)
+          .withFeature(AppendOnlyTableFeature)
+      )
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaVariantSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaVariantSuite.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.SparkThrowable
+import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.delta.actions.{Protocol, TableFeatureProtocolUtils}
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.types.StructType
+
+class DeltaVariantSuite
+    extends QueryTest
+    with DeltaSQLCommandTest {
+
+  private def getProtocolForTable(table: String): Protocol = {
+    val deltaLog = DeltaLog.forTable(spark, TableIdentifier(table))
+    deltaLog.unsafeVolatileSnapshot.protocol
+  }
+
+  test("create a new table with Variant, higher protocol and feature should be picked.") {
+    withTable("tbl") {
+      sql("CREATE TABLE tbl(s STRING, v VARIANT) USING DELTA")
+      sql("INSERT INTO tbl (SELECT 'foo', parse_json(cast(id + 99 as string)) FROM range(1))")
+      // TODO(r.chen): Enable once `parse_json` is properly implemented in OSS Spark.
+      // assert(spark.table("tbl").selectExpr("v::int").head == Row(99))
+      assert(
+        getProtocolForTable("tbl") ==
+        VariantTypeTableFeature.minProtocolVersion.withFeature(VariantTypeTableFeature)
+      )
+    }
+  }
+
+  test("creating a table without Variant should use the usual minimum protocol") {
+    withTable("tbl") {
+      sql("CREATE TABLE tbl(s STRING, i INTEGER) USING DELTA")
+      assert(getProtocolForTable("tbl") == Protocol(1, 2))
+
+      val deltaLog = DeltaLog.forTable(spark, TableIdentifier("tbl"))
+      assert(
+        !deltaLog.unsafeVolatileSnapshot.protocol.isFeatureSupported(VariantTypeTableFeature),
+        s"Table tbl contains VariantTypeFeature descriptor when its not supposed to"
+      )
+    }
+  }
+
+  test("add a new Variant column should upgrade to the correct protocol versions") {
+    withTable("tbl") {
+      sql("CREATE TABLE tbl(s STRING) USING delta")
+      assert(getProtocolForTable("tbl") == Protocol(1, 2))
+
+      // Should throw error
+      val e = intercept[SparkThrowable] {
+        sql("ALTER TABLE tbl ADD COLUMN v VARIANT")
+      }
+      // capture the existing protocol here.
+      // we will check the error message later in this test as we need to compare the
+      // expected schema and protocol
+      val deltaLog = DeltaLog.forTable(spark, TableIdentifier("tbl"))
+      val currentProtocol = deltaLog.unsafeVolatileSnapshot.protocol
+      val currentFeatures = currentProtocol.implicitlyAndExplicitlySupportedFeatures
+        .map(_.name)
+        .toSeq
+        .sorted
+        .mkString(", ")
+
+      // add table feature
+      sql(
+        s"ALTER TABLE tbl " +
+        s"SET TBLPROPERTIES('delta.feature.variantType-dev' = 'supported')"
+      )
+
+      sql("ALTER TABLE tbl ADD COLUMN v VARIANT")
+
+      // check previously thrown error message
+      checkError(
+        e,
+        errorClass = "DELTA_FEATURES_REQUIRE_MANUAL_ENABLEMENT",
+        parameters = Map(
+          "unsupportedFeatures" -> VariantTypeTableFeature.name,
+          "supportedFeatures" -> currentFeatures
+        )
+      )
+
+      sql("INSERT INTO tbl (SELECT 'foo', parse_json(cast(id + 99 as string)) FROM range(1))")
+      // TODO(r.chen): Enable once `parse_json` is properly implemented in OSS Spark.
+      // assert(spark.table("tbl").selectExpr("v::int").head == Row(99))
+
+      assert(
+        getProtocolForTable("tbl") ==
+        VariantTypeTableFeature.minProtocolVersion
+          .withFeature(VariantTypeTableFeature)
+          .withFeature(InvariantsTableFeature)
+          .withFeature(AppendOnlyTableFeature)
+      )
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaVariantSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaVariantSuite.scala
@@ -36,7 +36,7 @@ class DeltaVariantSuite
     withTable("tbl") {
       sql("CREATE TABLE tbl(s STRING, v VARIANT) USING DELTA")
       sql("INSERT INTO tbl (SELECT 'foo', parse_json(cast(id + 99 as string)) FROM range(1))")
-      // TODO(r.chen): Enable once `parse_json` is properly implemented in OSS Spark.
+      // TODO(r.chen): Enable once variant casting is properly implemented in OSS Spark.
       // assert(spark.table("tbl").selectExpr("v::int").head == Row(99))
       assert(
         getProtocolForTable("tbl") ==
@@ -97,7 +97,7 @@ class DeltaVariantSuite
       )
 
       sql("INSERT INTO tbl (SELECT 'foo', parse_json(cast(id + 99 as string)) FROM range(1))")
-      // TODO(r.chen): Enable once `parse_json` is properly implemented in OSS Spark.
+      // TODO(r.chen): Enable once variant casting is properly implemented in OSS Spark.
       // assert(spark.table("tbl").selectExpr("v::int").head == Row(99))
 
       assert(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

POC that shows kernel implementation of extracting variant child fields to return directly to the connector so the connector does not need to understand how to decode variants.

note this PR doesn't actually implement `variant_get` to return the correct field. Instead it just returns a dummy value. This PR is meant to show how connectors could use the new API

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
